### PR TITLE
fix: set trivy version to v0.61.1

### DIFF
--- a/.github/workflows/terraform-module-matrix.yml
+++ b/.github/workflows/terraform-module-matrix.yml
@@ -85,7 +85,7 @@ on:
         type: string
       trivy_version:
         description: 'Trivy version to use'
-        default: 'latest'
+        default: 'v0.61.1' # fixme: hardcoding version until problems in 0.62.0 are solved.
         required: false
         type: string
       commit_user:


### PR DESCRIPTION
 - set trivy version to v0.61.1 that works now until problem is fixed in 0.62.0