### PR TITLE
fix: adding option to skip terraform-docs

### DIFF
--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -231,8 +231,8 @@ jobs:
     needs:
       - terraform-fmt
       - terraform-docs
-    # the next job should only run if there are no new commits from terraform-fmt or terraform-docs
-    # if terraform-docs is disabled, it should only run if terraform-fmt has no changes
+    # this job should only run if there are no new commits caused by terraform-fmt or terraform-docs
+    # if terraform-docs is disabled, it should only run if terraform-fmt caused no changes
     if: ${{ always() && !failure() && !cancelled() && needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
@@ -283,7 +283,9 @@ jobs:
       - terraform-fmt
       - terraform-docs
       - terraform-lint
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    # this job should only run if there are no new commits caused by terraform-fmt or terraform-docs
+    # if terraform-docs is disabled, it should only run if terraform-fmt caused no changes
+    if: ${{ always() && !failure() && !cancelled() && needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       security_status: ${{ steps.security.outcome }}
@@ -327,7 +329,10 @@ jobs:
       - terraform-docs
       - terraform-lint
       - terraform-security
-    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    # this job should only run if there are no new commits caused by terraform-fmt or terraform-docs
+    # if terraform-docs is disabled, it should only run if terraform-fmt caused no changes
+    # also only run this job if terraform execution is enabled
+    if: ${{ always() && !failure() && !cancelled() && inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       execution_status: ${{ steps.plan.outcome || steps.apply.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -231,7 +231,9 @@ jobs:
     needs:
       - terraform-fmt
       - terraform-docs
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    # the next job should only run if there are no new commits from terraform-fmt or terraform-docs
+    # if terraform-docs is disabled, it should only run if terraform-fmt has no changes
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (true || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -233,7 +233,7 @@ jobs:
       - terraform-docs
     # the next job should only run if there are no new commits from terraform-fmt or terraform-docs
     # if terraform-docs is disabled, it should only run if terraform-fmt has no changes
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' }}
+    if: ${{ always() && !failure() && !cancelled() && needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -233,7 +233,7 @@ jobs:
       - terraform-docs
     # the next job should only run if there are no new commits from terraform-fmt or terraform-docs
     # if terraform-docs is disabled, it should only run if terraform-fmt has no changes
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (true || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -231,7 +231,7 @@ jobs:
     needs:
       - terraform-fmt
       - terraform-docs
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || (needs.terraform-docs.result == 'success' && needs.terraform-docs.outputs.diff_exists == 'false')) }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}
@@ -281,7 +281,7 @@ jobs:
       - terraform-fmt
       - terraform-docs
       - terraform-lint
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || (needs.terraform-docs.result == 'success' && needs.terraform-docs.outputs.diff_exists == 'false')) }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       security_status: ${{ steps.security.outcome }}
@@ -325,7 +325,7 @@ jobs:
       - terraform-docs
       - terraform-lint
       - terraform-security
-    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || (needs.terraform-docs.result == 'success' && needs.terraform-docs.outputs.diff_exists == 'false')) }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       execution_status: ${{ steps.plan.outcome || steps.apply.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -231,7 +231,7 @@ jobs:
     needs:
       - terraform-fmt
       - terraform-docs
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || (needs.terraform-docs.result == 'success' && needs.terraform-docs.outputs.diff_exists == 'false')) }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}
@@ -281,7 +281,7 @@ jobs:
       - terraform-fmt
       - terraform-docs
       - terraform-lint
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || (needs.terraform-docs.result == 'success' && needs.terraform-docs.outputs.diff_exists == 'false')) }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       security_status: ${{ steps.security.outcome }}
@@ -325,7 +325,7 @@ jobs:
       - terraform-docs
       - terraform-lint
       - terraform-security
-    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || (needs.terraform-docs.result == 'success' && needs.terraform-docs.outputs.diff_exists == 'false')) }}
+    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       execution_status: ${{ steps.plan.outcome || steps.apply.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -233,7 +233,7 @@ jobs:
       - terraform-docs
     # the next job should only run if there are no new commits from terraform-fmt or terraform-docs
     # if terraform-docs is disabled, it should only run if terraform-fmt has no changes
-    if: ${{ always() && !failure() && !cancelled() && needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ always() && !failure() && !cancelled() && needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -13,6 +13,11 @@ on:
         default: false
         required: false
         type: boolean
+      enable_terraform_docs:
+        description: 'Enable terraform-docs to generate documentation'
+        default: true
+        required: false
+        type: boolean
       enable_terraform_execution:
         description: 'Enable terraform plan on pull requests and apply on push to default branch'
         default: false
@@ -185,7 +190,7 @@ jobs:
   terraform-docs:
     needs:
       - terraform-fmt
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' }}
+    if: ${{ inputs.enable_terraform_docs && needs.terraform-fmt.outputs.diff_exists == 'false' }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       docs_status: ${{ steps.docs.outcome }}
@@ -226,7 +231,7 @@ jobs:
     needs:
       - terraform-fmt
       - terraform-docs
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && needs.terraform-docs.outputs.diff_exists == 'false' }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}
@@ -276,7 +281,7 @@ jobs:
       - terraform-fmt
       - terraform-docs
       - terraform-lint
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && needs.terraform-docs.outputs.diff_exists == 'false' }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       security_status: ${{ steps.security.outcome }}
@@ -320,7 +325,7 @@ jobs:
       - terraform-docs
       - terraform-lint
       - terraform-security
-    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && needs.terraform-docs.outputs.diff_exists == 'false' }}
+    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (needs.terraform-docs.result == 'skipped' || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       execution_status: ${{ steps.plan.outcome || steps.apply.outcome }}

--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -231,7 +231,7 @@ jobs:
     needs:
       - terraform-fmt
       - terraform-docs
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       lint_status: ${{ steps.lint.outcome }}
@@ -281,7 +281,7 @@ jobs:
       - terraform-fmt
       - terraform-docs
       - terraform-lint
-    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       security_status: ${{ steps.security.outcome }}
@@ -325,7 +325,7 @@ jobs:
       - terraform-docs
       - terraform-lint
       - terraform-security
-    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (inputs.enable_terraform_docs == 'false' || needs.terraform-docs.outputs.diff_exists == 'false') }}
+    if: ${{ inputs.enable_terraform_execution && needs.terraform-fmt.outputs.diff_exists == 'false' && (!inputs.enable_terraform_docs || needs.terraform-docs.outputs.diff_exists == 'false') }}
     runs-on: ${{ inputs.github_runner }}
     outputs:
       execution_status: ${{ steps.plan.outcome || steps.apply.outcome }}

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The Terraform Stack workflow consists of the following steps:
 
 `Always Runs`
 1. **Terraform Format** - Code formatting with auto-commit
-2. **Terraform Docs** - Documentation generation 
+2. **Terraform Docs** - Documentation generation (can be disabled with `enable_terraform_docs: false`)
 3. **Terraform Lint** - Static code analysis with TFLint
 4. **Terraform Security** - Security scanning with Trivy
 
@@ -171,6 +171,7 @@ The Terraform Stack workflow consists of the following steps:
 |------|-------------|---------|----------|
 | `github_runner` | Name of GitHub-hosted runner or self-hosted runner | `ubuntu-latest` | false |
 | `use_opentofu` | Use OpenTofu instead of Terraform | `false` | false |
+| `enable_terraform_docs` | Enable terraform-docs to generate documentation | `true` | false |
 | `enable_terraform_execution` | Enable terraform plan on pull requests and apply on push to default branch | `false` | false |
 | `aws_default_region` | Default AWS region to use for terraform execution | `eu-central-1` | false |
 | `aws_oidc_role_arn` | AWS OIDC role ARN to assume for terraform execution | `""` | false |


### PR DESCRIPTION
terraform-docs is not compatible with dynamic providers (OpenTofu).
in those cases we want to disable the terraform-docs step so that the rest of workflow gets executed.