### PR TITLE
fix: pass token for get tflint step

### DIFF
--- a/.github/workflows/terraform-stack.yml
+++ b/.github/workflows/terraform-stack.yml
@@ -263,6 +263,7 @@ jobs:
           source-path: ${{ inputs.tflint_repo_config_path }}
           source-ref: ${{ inputs.tflint_repo_ref }}
           destination-path: .tflint.hcl
+          token: ${{ steps.github_app_token.outputs.token }}
 
       - name: Run TFLint
         uses: reviewdog/action-tflint@v1


### PR DESCRIPTION
fix: to not run into rate limit issues it's a good practice to pass the token for higher rate limits.