### PR TITLE
fix: fix terratest dir checking

### DIFF
--- a/.github/workflows/terraform-module-test.yml
+++ b/.github/workflows/terraform-module-test.yml
@@ -346,8 +346,8 @@ jobs:
 
       - name: Check For Required Terratest Directory
         run: |
-          if [[ ! -d "./${{ inputs.terratest_path }}/complete" ]]; then
-            echo "could not find required directory '${{ inputs.terratest_path }}/complete' for terratest"
+          if [[ ! -d "./${{ inputs.terratest_path }}" ]]; then
+            echo "could not find required directory '${{ inputs.terratest_path }}' for terratest"
             exit 1
           fi
       


### PR DESCRIPTION
fixes the bug introduced at https://github.com/nuvibit/github-terraform-workflows/commit/b9f94167e071f11452680a87ad939e5c6be14bdb when it checks for the terratest directory.
it should check if test/ folder exists, not test/complete