### PR TITLE
fix: Update Trivy version to 'latest' in workflow

### DIFF
--- a/.github/workflows/terraform-module-test.yml
+++ b/.github/workflows/terraform-module-test.yml
@@ -105,7 +105,7 @@ on:
         type: string
       trivy_version:
         description: 'Trivy version to use'
-        default: 'latest' # fixme: hardcoding version until problems in 0.62.0 are solved.
+        default: 'latest'
         required: false
         type: string
       commit_user:

--- a/.github/workflows/terraform-module-test.yml
+++ b/.github/workflows/terraform-module-test.yml
@@ -50,7 +50,7 @@ on:
         type: string
       terratest_version:
         description: 'Terratest version'
-        default: 'v0.48.0'
+        default: 'v0.56.0'
         required: false
         type: string
       terratest_path:

--- a/.github/workflows/terraform-module-test.yml
+++ b/.github/workflows/terraform-module-test.yml
@@ -105,7 +105,7 @@ on:
         type: string
       trivy_version:
         description: 'Trivy version to use'
-        default: 'v0.61.1' # fixme: hardcoding version until problems in 0.62.0 are solved.
+        default: 'latest' # fixme: hardcoding version until problems in 0.62.0 are solved.
         required: false
         type: string
       commit_user:


### PR DESCRIPTION
the v.1.6.1 release is not available anymore and the issues we had before with newer versions are fixed.
Also update terratest to v0.56.0