### PR TITLE
fix: correct provider version lookup in terraform lock file generation

### DIFF
--- a/.github/workflows/terraform-module-test.yml
+++ b/.github/workflows/terraform-module-test.yml
@@ -537,8 +537,8 @@ jobs:
                 version_match=$(grep -zoP "required_providers\W*\{(.|\n)*?source\W*=\W*\"$provider\"(.|\n)*?version\W*=\W*\"\D*?(\d+\.\d+\.?\d*)" $GITHUB_WORKSPACE/*.tf | grep -zoP '(\d+\.\d+\.?\d*)' || true)
                 version=$(echo $version_match | grep -zoP '[\d\.]+' || true)
                 if [[ -z "$version" ]]; then
-                  echo "ERROR: could not determine version for provider '$provider' from requirements file" >&2
-                  exit 1
+                  echo "WARNING: provider '$provider' not found in requirements file, skipping" >&2
+                  continue
                 fi
                 num="${version//[^.]}"
                 count="${#num}"

--- a/.github/workflows/terraform-module-test.yml
+++ b/.github/workflows/terraform-module-test.yml
@@ -504,7 +504,7 @@ jobs:
             touch "$d/.terraform.lock.hcl"
             # get required provider versions from matrix json
             for provider in $(jq -r 'keys | .[]' <<< $PROVIDER_JSON); do
-              version=$(jq -r ".[$k]" <<< $PROVIDER_JSON)
+              version=$(jq -r --arg p "$provider" '.[$p]' <<< $PROVIDER_JSON)
               # get provider version if contains X from terraform registry
               if [[ "$version" == *"X"* ]]; then
                 for i in $(curl -s https://registry.terraform.io/v1/providers/$provider | jq -r '.versions' | jq 'reverse' | jq '.[]'); do
@@ -534,8 +534,12 @@ jobs:
                   fi
                 done
               elif [[ "$version" == "FROM_REQUIREMENTS" ]]; then
-                version_match=$(grep -zoP "required_providers\W*\{(.|\n)*?source\W*=\W*\"$provider\"(.|\n)*?version\W*=\W*\"\D*?(\d+\.\d+\.?\d*)" $GITHUB_WORKSPACE/*.tf | grep -zoP '(\d+\.\d+\.?\d*)')
-                version=$(echo $version_match | grep -zoP '[\d\.]+')
+                version_match=$(grep -zoP "required_providers\W*\{(.|\n)*?source\W*=\W*\"$provider\"(.|\n)*?version\W*=\W*\"\D*?(\d+\.\d+\.?\d*)" $GITHUB_WORKSPACE/*.tf | grep -zoP '(\d+\.\d+\.?\d*)' || true)
+                version=$(echo $version_match | grep -zoP '[\d\.]+' || true)
+                if [[ -z "$version" ]]; then
+                  echo "ERROR: could not determine version for provider '$provider' from requirements file" >&2
+                  exit 1
+                fi
                 num="${version//[^.]}"
                 count="${#num}"
                 if [[ $count == 1 ]]; then


### PR DESCRIPTION
## Motivation

- The lock-file generation failed because the shared Terratest matrix (aws/matrix.json) lists hashicorp/aws as a required provider. The module https://github.com/nuvibit-terraform-collection/terraform-spacelift-ntc-administration does not use the AWS provider and therefore had no hashicorp/aws entry in its required_providers block. Therefore I changed the code, so that providers will be skipped that cannot be resolved from requirements
## Summary

- Fix undefined `$k` variable in jq lookup — use `--arg p "$provider"` so the loop variable is passed correctly; with multiple providers the old code would have read the wrong key
- Suppress `grep` non-zero exit codes with `|| true` to prevent `bash -e` from aborting the script when a provider is not found in the requirements file
- Skip providers that cannot be resolved from requirements (e.g. AWS provider not pinned in a module) instead of failing the entire lock file generation step

## Test plan

- [x] Workflow run with a single provider in matrix produces a correct lock file
- [x] Workflow run with multiple providers in matrix produces correct entries for each
- [x] `FROM_REQUIREMENTS` with a provider that has no version constraint in `.tf` files emits a warning and continues without failing